### PR TITLE
Fix Urlum+ icon references

### DIFF
--- a/OPX-JoolPlus/KopernicusConfigs/01-Meto.cfg
+++ b/OPX-JoolPlus/KopernicusConfigs/01-Meto.cfg
@@ -64,7 +64,7 @@
 			argumentOfPeriapsis = 274.588
 			meanAnomalyAtEpoch = 0
 			epoch = 0
-			iconTexture = OPX-UrlumPlus/Textures/PluginData/Small.png
+			iconTexture = OPX-JoolPlus/Textures/PluginData/Small.png
 		}	
 		ScaledVersion
 		{

--- a/OPX-JoolPlus/KopernicusConfigs/02-Alnes.cfg
+++ b/OPX-JoolPlus/KopernicusConfigs/02-Alnes.cfg
@@ -67,7 +67,7 @@
             longitudeOfAscendingNode = 169.02
             argumentOfPeriapsis = 203.84
             meanAnomalyAtEpoch = 17.414
-			iconTexture = OPX-UrlumPlus/Textures/PluginData/Large.png
+			iconTexture = OPX-JoolPlus/Textures/PluginData/Large.png
         }
         ScaledVersion
         {

--- a/OPX-JoolPlus/KopernicusConfigs/07-Bop.cfg
+++ b/OPX-JoolPlus/KopernicusConfigs/07-Bop.cfg
@@ -12,7 +12,7 @@
 			%argumentOfPeriapsis = 275.933
 			%meanAnomalyAtEpoch = 85.091
 			%epoch = 0
-			%iconTexture = OPX-UrlumPlus/Textures/PluginData/Large.png
+			%iconTexture = OPX-JoolPlus/Textures/PluginData/Large.png
 		}	
 		@PQS
 		{

--- a/OPX-JoolPlus/KopernicusConfigs/08-Pol.cfg
+++ b/OPX-JoolPlus/KopernicusConfigs/08-Pol.cfg
@@ -8,7 +8,7 @@
             %eccentricity = 0.2522
             %inclination = 9.281
             %referenceBody = BetterJool
-            %iconTexture = OPX-UrlumPlus/Textures/PluginData/Large.png
+            %iconTexture = OPX-JoolPlus/Textures/PluginData/Large.png
 		}
         %Properties
         {


### PR DESCRIPTION
Pol, Bop, Alnes, Meto referenced textures in Urlum Plus for their icon textures, replaced with the Large.png and Small.png in Jool Plus itself.