### PR TITLE
Fixed invalid specifiers

### DIFF
--- a/OPX-JoolPlus/Patches/OPX-JoolPlus-BetterJoolReparent.cfg
+++ b/OPX-JoolPlus/Patches/OPX-JoolPlus-BetterJoolReparent.cfg
@@ -1,10 +1,21 @@
 @Kopernicus:LAST[Z_OPX-JoolPlus] // This mod removes the stock Jool object, meaning that anything that orbits it will throw a nullref and break the game unless reparented to the replacement. This config does that with every possible object orbiting Jool. 
 {
-  @Body:HAS[@Orbit:HAS[#referenceBody[Jool]]]
-  {
-    @Orbit
-    {
-      @referenceBody = BetterJool
-    }
-  }
+	@Body:HAS[@Orbit:HAS[#referenceBody[Jool]]]
+	{
+		@Orbit
+		{
+			@referenceBody = BetterJool
+		}
+	}
+}
+
+@Kopernicus:LAST[Z_OPX-JoolPlus]:HAS[@OPX_JoolPlus_Settings:HAS[#CloverJoolRetextureOverride[?rue]]]
+{
+	@Body:HAS[@Orbit:HAS[#referenceBody[Jool]]]
+	{
+		@Orbit
+		{
+			@referenceBody = JoolC
+		}
+	}
 }

--- a/OPX-JoolPlus/Patches/OPX-KcalbelohCompatibility.cfg
+++ b/OPX-JoolPlus/Patches/OPX-KcalbelohCompatibility.cfg
@@ -1,10 +1,22 @@
-@Kopernicus:FOR[OPX-JoolPlus]:NEEDS[KcalbelohSystem]:NEEDS[!OPM]
+@Kopernicus:NEEDS[KcalbelohSystem,!OPM]:LAST[Kopernicus]
 {
     @Body[WH3141A]
     {
         @Orbit
         {
-            %referenceBody = BetterJool
+			%referenceBody = BetterJool
+			%semiMajorAxis = 331210000
+        }
+    }
+}
+
+@Kopernicus:NEEDS[KcalbelohSystem,!OPM]:HAS[@OPX_JoolPlus_Settings:HAS[#CloverJoolRetextureOverride[True]]]:LAST[Kopernicus]
+{
+    @Body[WH3141A]
+    {
+        @Orbit
+        {
+            %referenceBody = JoolC
         }
     }
 }


### PR DESCRIPTION
Reparenting is now compatible with Jool Revamp.
Kcalbeloh patch has been fixed and is compatible with Jool Revamp.